### PR TITLE
Prevent python-eggs extraction errors

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ setup(
     author_email='esn@dmi.dk',
     packages = ['pykdtree'],
     install_requires=['numpy'],
+    zip_safe=False,
     ext_modules = [Extension('pykdtree.kdtree', 
                              ['pykdtree/kdtree.c', 'pykdtree/_kdtree_core.c'],
                              include_dirs=[numpy.get_include()])], 


### PR DESCRIPTION
Currently, pykdtree installs itself as a compressed egg in site-packages.

The eggs unzips at runtime into ~/.python-eggs.

Sometimes, ~/.python-eggs has permission issues which causes subsequent scripts to fail or issue warnings.

The proposed change prevents zip compression during installation.
