### PR TITLE
Fix bug when numpy isn't installed and builtins is a dict

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,14 @@ try:
 except KeyError:
     use_omp = True
 
+
+def set_builtin(name, value):
+    if isinstance(__builtins__, dict):
+        __builtins__[name] = value
+    else:
+        setattr(__builtins__, name, value)
+
+
 # Custom builder to handler compiler flags. Edit if needed.
 class build_ext_subclass(build_ext):
     def build_extensions(self):
@@ -54,11 +62,11 @@ class build_ext_subclass(build_ext):
         '''
         In order to avoid premature import of numpy before it gets installed as a dependency
         get numpy include directories during the extensions building process
-	http://stackoverflow.com/questions/19919905/how-to-bootstrap-numpy-installation-in-setup-py
+        http://stackoverflow.com/questions/19919905/how-to-bootstrap-numpy-installation-in-setup-py
         '''
         build_ext.finalize_options(self)
         # Prevent numpy from thinking it is still in its setup process:
-        __builtins__.__NUMPY_SETUP__ = False
+        set_builtin('__NUMPY_SETUP__', False)
         import numpy
         self.include_dirs.append(numpy.get_include())
  


### PR DESCRIPTION
We had a pytroll user run in to this issue which we have run in to with pyresample. Sometimes the `builtins` object is a dict so setting the `__NUMPY_SETUP__` attribute raises an error when trying to pip install in an environment that doesn't have numpy installed:

      File "/usr/lib/python2.7/distutils/cmd.py", line 109, in ensure_finalized
        self.finalize_options()
      File "/tmp/easy_install-3hVolb/pykdtree-1.2.1/setup.py", line 61, in finalize_options
        :returns: list of 2-element tuples compatible with `setuptools.setup`
      AttributeError: 'dict' object has no attribute '__NUMPY_SETUP__'