### PR TITLE
Add license file to source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 exclude pykdtree/render_template.py
+include LICENSE.txt

--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,7 @@ setup(
     author='Esben S. Nielsen',
     author_email='storpipfugl@gmail.com',
     packages = ['pykdtree'],
+    python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*',
     install_requires=['numpy'],
     setup_requires=['numpy'],
     tests_require=['nose'],


### PR DESCRIPTION
See https://github.com/conda-forge/pykdtree-feedstock/pull/16

Basically to fulfill the GPL license, the source distribution should include a copy of the license file. This PR adds the license file to the sdist manifest. Also I added a `python_requires` which will help in the future if/when pykdtree drops python 2.7 support. It will make it so people downloading pykdtree from PyPI on python 2.7 don't get the version of the package that has dropped python 2.7 support.

@mraspaud I think I mentioned the need for this PR last week.