### PR TITLE
Clarify shapes of query and mask points.

### DIFF
--- a/pykdtree/kdtree.pyx
+++ b/pykdtree/kdtree.pyx
@@ -135,7 +135,7 @@ cdef class KDTree:
 
         :Parameters:
         query_pts : numpy array
-            Query points with shape (n , dims)
+            Query points with shape (m, dims)
         k : int
             The number of nearest neighbours to return
         eps : non-negative float
@@ -151,8 +151,8 @@ cdef class KDTree:
         mask : numpy array, optional
             Array of booleans where neighbors are considered invalid and
             should not be returned. A mask value of True represents an
-            invalid pixel. Mask should have shape (n,). By default all
-            points are considered valid.
+            invalid pixel. Mask should have shape (n,) to match data points.
+            By default all points are considered valid.
 
         """
 


### PR DESCRIPTION
Query points does not necessarily have to be the same length as the data points, and mask points should be. Use different letters to make that clear.