### PR TITLE
Fix for python3 rpm-build

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bdist_rpm]
-requires=numpy
+requires=python3-numpy
 release=1
 
 


### PR DESCRIPTION
This is necessary so that we can make rpm packages for python3.
It is, however, not backward compatible, so that with this PR it will no longer be possible to build and rpm for Python 2. BUT, this might be a good point in time to stop supporting Python2, as numpy, xarray, dask, and now also all Pytroll packages are skipping Python 2 support from Jan 1, 2020.