### PR TITLE
Add Azure pipelines configuration to build and deploy wheels

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,82 @@
+trigger:
+  branches:
+    include:
+      - '*'
+  tags:
+    include:
+      - v*
+variables:
+  CIBW_BUILDING: "true"
+  CIBW_SKIP: "cp27-* cp34-* cp35-*"
+  CIBW_TEST_REQUIRES: "pytest pytest-sugar"
+  CIBW_TEST_COMMAND: "python -c \"import pykdtree.kdtree\""
+  CIBW_BUILD_VERBOSITY: "2"
+  CIBW_BEFORE_BUILD: "pip install -U numpy Cython pip setuptools"
+  # needed until pykdtree auto-detects this
+  CIBW_ENVIRONMENT_MACOS: "USE_OMP=0"
+jobs:
+  - job: linux
+    pool: {vmImage: 'Ubuntu-16.04'}
+    steps:
+      - task: UsePythonVersion@0
+      - bash: |
+          git submodule update --init --recursive
+          python -m pip install --upgrade pip
+          pip install cibuildwheel twine numpy Cython
+          python setup.py sdist -d wheelhouse
+          cibuildwheel --output-dir wheelhouse .
+      - task: PublishPipelineArtifact@1
+        inputs:
+          path: $(System.DefaultWorkingDirectory)/wheelhouse
+          artifact: pykdtreeDeployLinux
+  - job: macos
+    pool: {vmImage: 'macOS-10.14'}
+    steps:
+      - task: UsePythonVersion@0
+      - bash: |
+          git submodule update --init --recursive
+          python -m pip install --upgrade pip
+          pip install cibuildwheel
+          cibuildwheel --output-dir wheelhouse .
+      - task: PublishPipelineArtifact@1
+        inputs:
+          path: $(System.DefaultWorkingDirectory)/wheelhouse
+          artifact: pykdtreeDeployMacOS
+  - job: windows
+    pool: {vmImage: 'vs2017-win2016'}
+    steps:
+      - {task: UsePythonVersion@0, inputs: {versionSpec: '3.6', architecture: x86}}
+      - {task: UsePythonVersion@0, inputs: {versionSpec: '3.6', architecture: x64}}
+      - {task: UsePythonVersion@0, inputs: {versionSpec: '3.7', architecture: x86}}
+      - {task: UsePythonVersion@0, inputs: {versionSpec: '3.7', architecture: x64}}
+      - bash: |
+          git submodule update --init --recursive
+          python -m pip install --upgrade pip
+          pip install cibuildwheel
+          cibuildwheel --output-dir wheelhouse .
+      - task: PublishPipelineArtifact@1
+        inputs:
+          path: $(System.DefaultWorkingDirectory)/wheelhouse
+          artifact: pykdtreeDeployWindows
+  - job: deployPyPI
+    pool: {vmImage: 'Ubuntu-16.04'}
+    condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/v'))
+    dependsOn:
+      - linux
+      - macos
+      - windows
+    steps:
+      - task: UsePythonVersion@0
+      - task: DownloadPipelineArtifact@2
+        inputs:
+          patterns: |
+            pykdtreeDeployLinux/*
+            pykdtreeDeployMacOS/*.whl
+            pykdtreeDeployWindows/*.whl
+      - bash: |
+          cd $(Pipeline.Workspace)
+          python -m pip install --upgrade pip
+          pip install twine
+          twine upload -u "__token__" --skip-existing pykdtreeDeployLinux/* pykdtreeDeployMacOS/* pykdtreeDeployWindows/*
+        env:
+          TWINE_PASSWORD: $(pypiToken)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,8 +12,6 @@ variables:
   CIBW_TEST_COMMAND: "python -c \"import pykdtree.kdtree\""
   CIBW_BUILD_VERBOSITY: "2"
   CIBW_BEFORE_BUILD: "pip install -U numpy Cython pip setuptools"
-  # needed until pykdtree auto-detects this
-  CIBW_ENVIRONMENT_MACOS: "USE_OMP=0"
 jobs:
   - job: linux
     pool: {vmImage: 'Ubuntu-16.04'}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,6 +47,8 @@ jobs:
       - {task: UsePythonVersion@0, inputs: {versionSpec: '3.6', architecture: x64}}
       - {task: UsePythonVersion@0, inputs: {versionSpec: '3.7', architecture: x86}}
       - {task: UsePythonVersion@0, inputs: {versionSpec: '3.7', architecture: x64}}
+      - {task: UsePythonVersion@0, inputs: {versionSpec: '3.8', architecture: x86}}
+      - {task: UsePythonVersion@0, inputs: {versionSpec: '3.8', architecture: x64}}
       - bash: |
           git submodule update --init --recursive
           python -m pip install --upgrade pip

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,12 +43,7 @@ jobs:
   - job: windows
     pool: {vmImage: 'vs2017-win2016'}
     steps:
-      - {task: UsePythonVersion@0, inputs: {versionSpec: '3.6', architecture: x86}}
-      - {task: UsePythonVersion@0, inputs: {versionSpec: '3.6', architecture: x64}}
-      - {task: UsePythonVersion@0, inputs: {versionSpec: '3.7', architecture: x86}}
-      - {task: UsePythonVersion@0, inputs: {versionSpec: '3.7', architecture: x64}}
-      - {task: UsePythonVersion@0, inputs: {versionSpec: '3.8', architecture: x86}}
-      - {task: UsePythonVersion@0, inputs: {versionSpec: '3.8', architecture: x64}}
+      - task: UsePythonVersion@0
       - bash: |
           git submodule update --init --recursive
           python -m pip install --upgrade pip


### PR DESCRIPTION
Closes #33 

Builds and uploads wheels for Linux, OSX, and Windows. This is based on similar work I did for VisPy and that I am now trying to do for pyresample. Since I was already doing it for pyresample I copied it over to pykdtree too (sorry @akaszynski I know you were working on this too).

I'm not sure how easy this will be to test without also merging it to the `storpipfugl` copy of the repository and setting of the Azure group/pipeline from there. I haven't completely figured it out for pyresample yet.