### PR TITLE
Add Github Action to build wheels

### DIFF
--- a/.github/workflows/deploy-wheels.yml
+++ b/.github/workflows/deploy-wheels.yml
@@ -1,0 +1,83 @@
+---
+name: Deploy wheels
+
+on:
+  push:
+  release:
+    types:
+      - published
+jobs:
+  build:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, macos-latest]
+        python-version: [3.5, 3.6, 3.7, 3.8]
+        include:
+          # Using pythons inside a docker image to provide all the Linux
+          # python-versions permutations.
+          - name: manylinux 64-bit
+            os: ubuntu-latest
+            python-version: 3.8
+            docker-image: manylinux1_x86_64
+          - name: manylinux 32-bit
+            os: ubuntu-latest
+            python-version: 3.8
+            docker-image: manylinux1_i686
+
+    steps:
+      - uses: actions/checkout@v2
+      - run: |
+          git fetch --prune --unshallow
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install -U -q pip pytest wheel setuptools twine numpy
+
+      - name: Build and install macOS/Windows wheel
+        if: matrix.os != 'ubuntu-latest'
+        run: |
+          python setup.py -q bdist_wheel
+          pip install --find-links=./dist/ pykdtree
+
+      - name: Test
+        if: matrix.os != 'ubuntu-latest'
+        run: |
+          pytest -v --pyargs pykdtree
+
+      - name: Build Linux wheels inside docker
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          docker run \
+            -e PLAT=${{ matrix.docker-image }} \
+            -e USE_OMP=1 \
+            -v `pwd`:/io \
+            quay.io/pypa/${{ matrix.docker-image }} \
+            /io/scripts/build-manylinux-wheels.sh
+
+      - name: Upload wheel(s) as build artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: wheels
+          path: dist/*.whl
+
+      - name: Publish package to PyPI
+        if: github.event.action == 'published'
+        env:
+          TWINE_USERNAME: ${{ secrets.pypi_username }}
+          TWINE_PASSWORD: ${{ secrets.pypi_password }}
+        run: twine upload --skip-existing dist/*.whl
+
+      - name: Publish package to TestPyPI
+        env:
+          TWINE_USERNAME: ${{ secrets.test_pypi_username }}
+          TWINE_PASSWORD: ${{ secrets.test_pypi_password }}
+        run: |
+          twine upload --repository-url https://test.pypi.org/legacy/ --skip-existing dist/*.whl

--- a/scripts/build-manylinux-wheels.sh
+++ b/scripts/build-manylinux-wheels.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+set -e -x
+
+# This is to be run by Docker inside a Docker image.
+# You can test it locally on a Linux machine by installing docker and running from this repo's root:
+# $ docker run -e PLAT=manylinux1_x86_64 -v `pwd`:/io quay.io/pypa/manylinux1_x86_64 /io/scripts/build-manylinux-wheels.sh
+
+# * The -e just defines an environment variable PLAT=[docker name] inside the
+#    docker - auditwheel can't detect the docker name automatically.
+# * The -v gives a directory alias for passing files in and out of the docker
+#    (/io is arbitrary). E.g the `setup.py` script would be accessed in the
+#    docker via `/io/setup.py`.
+# * quay.io/pypa/manylinux1_x86_64 is the full docker image name. Docker
+#    downloads it automatically.
+# * The last argument is a shell command that the Docker will execute.
+#    Filenames must be from the Docker's perspective.
+
+# Wheels are initially generated as you would usually, but put in a temp
+# directory temp-wheels. The pip-cache is optional but can speed up local builds
+# having a real permanent pip-cache dir.
+mkdir -p /io/pip-cache
+mkdir -p /io/temp-wheels
+
+# Clean out any old existing wheels.
+find /io/temp-wheels/ -type f -delete
+
+# Iterate through available pythons.
+for PYBIN in /opt/python/cp3[5678]*/bin; do
+    "${PYBIN}/pip" install -q -U setuptools wheel nose --cache-dir /io/pip-cache
+    # Run the following in root of this repo.
+    (cd /io/ && USE_OMP=$USE_OMP "${PYBIN}/pip" install -q .)
+    (cd /io/ && USE_OMP=$USE_OMP "${PYBIN}/python" setup.py nosetests)
+    (cd /io/ && USE_OMP=$USE_OMP "${PYBIN}/python" setup.py -q bdist_wheel -d /io/temp-wheels)
+done
+
+"$PYBIN/pip" install -q auditwheel
+
+# Wheels aren't considered manylinux unless they have been through
+# auditwheel. Audited wheels go in /io/dist/.
+mkdir -p /io/dist/
+
+for whl in /io/temp-wheels/*.whl; do
+    auditwheel repair "$whl" --plat "$PLAT" -w /io/dist/
+done


### PR DESCRIPTION
CI workflow to build wheels for PyPi for Windows/macOS/manylinux, Pythons 3.5-3.8. Fixes #33.

Uses Github Actions which, unlike Appveyor, supports Docker (allowing manylinux) and doesn't require setting up an organisation like Azure Pipelines does. Latest build is [here](https://github.com/bwoodsend/pykdtree/actions/runs/202777945).

Wheels are:
- Built.
- Installed.
- Tested.
- Uploaded as build artefacts which you can download from the build's page.
- Uploaded to Test PyPi (requires setting login details `test_pypi_username` and `test_pypi_password` in your repositories secrets.
- On publishing a github release will also upload to regular PyPi (needs secrets `pypi_username` and `pypi_password`).

For some reason I couldn't get `nose` to find the tests on Windows and macOS so I swapped `nose` for `pytest --pyargs pykdtree` which does what we want it to.

I've tried to annotate it as best I can. Let me know if anything needs clarifying...
