### PR TITLE
Add pyx to the manifest (allow recythoning)

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 exclude pykdtree/render_template.py
 include LICENSE.txt
+include *.pyx


### PR DESCRIPTION
This allows future recythoning of the pyx file when the python c api changes.  (which it did for py39)