### PR TITLE
Fix pyx files not being included in sdist and add long_description and url to setup.py

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 exclude pykdtree/render_template.py
 include LICENSE.txt
+include README.rst
 include pykdtree/*.pyx

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
 exclude pykdtree/render_template.py
 include LICENSE.txt
-include *.pyx
+include pykdtree/*.pyx

--- a/setup.py
+++ b/setup.py
@@ -89,11 +89,15 @@ class build_ext_subclass(build_ext):
         import numpy
         self.include_dirs.append(numpy.get_include())
 
+with open('README.rst', 'r') as readme_file:
+    readme = readme_file.read()
 
 setup(
     name='pykdtree',
     version='1.3.2',
+    url="https://github.com/storpipfugl/pykdtree",
     description='Fast kd-tree implementation with OpenMP-enabled queries',
+    long_description=readme,
     author='Esben S. Nielsen',
     author_email='storpipfugl@gmail.com',
     packages=['pykdtree'],


### PR DESCRIPTION
Retry of #55. CC @mariusvniekerk @QuLogic 

This also adds `url` and `long_description` to the README so that it shows up on PyPI.