### PR TITLE
Fix Python 3.9 wheels not being built for linux

### DIFF
--- a/scripts/build-manylinux-wheels.sh
+++ b/scripts/build-manylinux-wheels.sh
@@ -25,7 +25,7 @@ mkdir -p /io/temp-wheels
 find /io/temp-wheels/ -type f -delete
 
 # Iterate through available pythons.
-for PYBIN in /opt/python/cp3[5678]*/bin; do
+for PYBIN in /opt/python/cp3[6789]*/bin; do
     "${PYBIN}/pip" install -q -U setuptools wheel nose --cache-dir /io/pip-cache
     # Run the following in root of this repo.
     (cd /io/ && USE_OMP=$USE_OMP "${PYBIN}/pip" install -q .)


### PR DESCRIPTION
This also removes Python 3.5 wheel building for linux.