### PR TITLE
Drop Python 3.6 from CI deployment/testing

### DIFF
--- a/.github/workflows/deploy-wheels.yml
+++ b/.github/workflows/deploy-wheels.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, macos-latest]
-        python-version: [3.7, 3.8, 3.9, 3.10]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
         include:
           # Using pythons inside a docker image to provide all the Linux
           # python-versions permutations.

--- a/.github/workflows/deploy-wheels.yml
+++ b/.github/workflows/deploy-wheels.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, macos-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
         include:
           # Using pythons inside a docker image to provide all the Linux
           # python-versions permutations.

--- a/.github/workflows/deploy-wheels.yml
+++ b/.github/workflows/deploy-wheels.yml
@@ -18,14 +18,6 @@ jobs:
         include:
           # Using pythons inside a docker image to provide all the Linux
           # python-versions permutations.
-          - name: manylinux 64-bit
-            os: ubuntu-latest
-            python-version: 3.8
-            docker-image: manylinux1_x86_64
-          - name: manylinux 32-bit
-            os: ubuntu-latest
-            python-version: 3.8
-            docker-image: manylinux1_i686
           - name: manylinux2010 64-bit
             os: ubuntu-latest
             python-version: 3.8

--- a/.github/workflows/deploy-wheels.yml
+++ b/.github/workflows/deploy-wheels.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, macos-latest]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, 3.10]
         include:
           # Using pythons inside a docker image to provide all the Linux
           # python-versions permutations.

--- a/.github/workflows/deploy-wheels.yml
+++ b/.github/workflows/deploy-wheels.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v1
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "${{ matrix.python-version }}"
 
       - name: Install dependencies
         run: |

--- a/scripts/build-manylinux-wheels.sh
+++ b/scripts/build-manylinux-wheels.sh
@@ -26,12 +26,12 @@ find /io/temp-wheels/ -type f -delete
 
 # Iterate through available pythons.
 for PYBIN in /opt/python/cp3[6789]*/bin; do
-    "${PYBIN}/pip" install -q -U setuptools wheel pytest --cache-dir /io/pip-cache
+    "${PYBIN}/pip" install -q -U setuptools wheel pytest build --cache-dir /io/pip-cache
     # Run the following in root of this repo.
     pushd /io/
     USE_OMP=$USE_OMP "${PYBIN}/pip" install -q .
     USE_OMP=$USE_OMP "${PYBIN}/pytest" --pyargs pykdtree
-    USE_OMP=$USE_OMP "${PYBIN}/python" setup.py -q bdist_wheel -d /io/temp-wheels
+    USE_OMP=$USE_OMP "${PYBIN}/python" -m build -w -o /io/temp-wheels
     popd
 done
 

--- a/scripts/build-manylinux-wheels.sh
+++ b/scripts/build-manylinux-wheels.sh
@@ -3,14 +3,14 @@ set -e -x
 
 # This is to be run by Docker inside a Docker image.
 # You can test it locally on a Linux machine by installing docker and running from this repo's root:
-# $ docker run -e PLAT=manylinux1_x86_64 -v `pwd`:/io quay.io/pypa/manylinux1_x86_64 /io/scripts/build-manylinux-wheels.sh
+# $ docker run -e PLAT=manylinux2010_x86_64 -v `pwd`:/io quay.io/pypa/manylinux2010_x86_64 /io/scripts/build-manylinux-wheels.sh
 
 # * The -e just defines an environment variable PLAT=[docker name] inside the
 #    docker - auditwheel can't detect the docker name automatically.
 # * The -v gives a directory alias for passing files in and out of the docker
 #    (/io is arbitrary). E.g the `setup.py` script would be accessed in the
 #    docker via `/io/setup.py`.
-# * quay.io/pypa/manylinux1_x86_64 is the full docker image name. Docker
+# * quay.io/pypa/manylinux2010_x86_64 is the full docker image name. Docker
 #    downloads it automatically.
 # * The last argument is a shell command that the Docker will execute.
 #    Filenames must be from the Docker's perspective.
@@ -26,15 +26,6 @@ find /io/temp-wheels/ -type f -delete
 
 # Iterate through available pythons.
 for PY in cp3{7,8,9,10}; do
-    if [[ $PLAT == manylinux2010* ]]; then
-        if [ "$PY" != "cp310" ]; then
-            continue
-        fi
-    else
-        if [ "$PY" = "cp310" ]; then
-            continue
-        fi
-    fi
     for PYBIN in /opt/python/"${PY}"*/bin; do
         "${PYBIN}/pip" install -q -U setuptools wheel pytest build --cache-dir /io/pip-cache
         # Run the following in root of this repo.

--- a/scripts/build-manylinux-wheels.sh
+++ b/scripts/build-manylinux-wheels.sh
@@ -25,7 +25,7 @@ mkdir -p /io/temp-wheels
 find /io/temp-wheels/ -type f -delete
 
 # Iterate through available pythons.
-for PY in cp3{6,7,8,9,10}; do
+for PY in cp3{7,8,9,10}; do
     if [[ $PLAT == manylinux2010* ]]; then
         if [ "$PY" != "cp310" ]; then
             continue

--- a/setup.py
+++ b/setup.py
@@ -101,7 +101,7 @@ setup(
     author='Esben S. Nielsen',
     author_email='storpipfugl@gmail.com',
     packages=['pykdtree'],
-    python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*',
+    python_requires='>=3.7',
     install_requires=['numpy'],
     setup_requires=['numpy'],
     tests_require=['pytest'],


### PR DESCRIPTION
Python 3.6 is no longer available from the usual sources so it isn't easy to test/build against it anymore. This PR removes it from the CI environment.