### PR TITLE
Disable OpenMP during OSX/Windows wheel building

### DIFF
--- a/.github/workflows/deploy-wheels.yml
+++ b/.github/workflows/deploy-wheels.yml
@@ -61,8 +61,9 @@ jobs:
 
       - name: Build and install macOS/Windows wheel
         if: matrix.os != 'ubuntu-latest'
+        env:
+          USE_OMP: 0
         run: |
-          USE_OMP=0
           python setup.py -v -q bdist_wheel
           pip install --find-links=./dist/ pykdtree
 

--- a/.github/workflows/deploy-wheels.yml
+++ b/.github/workflows/deploy-wheels.yml
@@ -62,7 +62,8 @@ jobs:
       - name: Build and install macOS/Windows wheel
         if: matrix.os != 'ubuntu-latest'
         run: |
-          python setup.py -q bdist_wheel
+          USE_OMP=0
+          python setup.py -v -q bdist_wheel
           pip install --find-links=./dist/ pykdtree
 
       - name: Test


### PR DESCRIPTION
@rayg-ssec noticed that the newest wheels have OpenMP in them and are therefore broken on most systems. Let's see how quick I can disable this.