### PR TITLE
Drop 32-bit wheel builds

### DIFF
--- a/.github/workflows/deploy-wheels.yml
+++ b/.github/workflows/deploy-wheels.yml
@@ -40,10 +40,6 @@ jobs:
             os: ubuntu-latest
             python-version: 3.8
             docker-image: manylinux_2_24_x86_64
-          - name: manylinux_2_24 32-bit
-            os: ubuntu-latest
-            python-version: 3.8
-            docker-image: manylinux_2_24_i686
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Numpy doesn't provide 32-bit wheels and our wheel building has started to fail due to it. We can't maintain a 32-bit version of numpy so we're dropping 32-bit builds.