### PR TITLE
Switch to Cython 3 in build process

### DIFF
--- a/pykdtree/kdtree.pyx
+++ b/pykdtree/kdtree.pyx
@@ -20,6 +20,7 @@ cimport numpy as np
 from libc.stdint cimport uint32_t, int8_t, uint8_t
 cimport cython
 
+np.import_array()
 
 # Node structure
 cdef struct node_float:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools", "wheel", "numpy", "Cython"]
+requires = ["setuptools", "numpy", "Cython>=3"]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -188,6 +188,7 @@ with open('README.rst', 'r') as readme_file:
 extensions = [
     Extension('pykdtree.kdtree', sources=['pykdtree/kdtree.pyx', 'pykdtree/_kdtree_core.c'],
               include_dirs=[np.get_include()],
+              define_macros=[("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION")],
               ),
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -189,6 +189,7 @@ extensions = [
     Extension('pykdtree.kdtree', sources=['pykdtree/kdtree.pyx', 'pykdtree/_kdtree_core.c'],
               include_dirs=[np.get_include()],
               define_macros=[("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION")],
+              compiler_directions={"language_level": "3"},
               ),
 ]
 


### PR DESCRIPTION
This PR doesn't necessarily address a specific issue, but rather prepares for one that I think is coming. This PR does a couple things:

1. Makes sure that old numpy APIs are not used.
2. Declares to numpy that it is/will be using the numpy C API in the cython module (to initialize numpy's internal API/state from my understanding).
3. Forces Cython 3+ to be used during the build process