### PR TITLE
Add OpenMP warning when extension fails to import

### DIFF
--- a/pykdtree/__init__.py
+++ b/pykdtree/__init__.py
@@ -1,0 +1,14 @@
+"""Simple wrapper around importing pykdtree for OpenMP use or not."""
+
+try:
+    from . import kdtree
+except ImportError:
+    import warnings
+    warnings.warn(
+        "Pykdtree failed to import its C extension. This usually means it "
+        "was built with OpenMP (C-level parallelization library) support but "
+        "could not find it on your system. To enable better performance "
+        "OpenMP must be installed (ex. ``brew install omp`` on Mac with "
+        "HomeBrew). Otherwise, try installing Pykdtree from source (ex. "
+        "``pip install --no-binary pykdtree --force-install pykdtree``)."
+    )

--- a/pykdtree/__init__.py
+++ b/pykdtree/__init__.py
@@ -2,13 +2,12 @@
 
 try:
     from . import kdtree
-except ImportError:
-    import warnings
-    warnings.warn(
+except ImportError as err:
+    raise ImportError(
         "Pykdtree failed to import its C extension. This usually means it "
         "was built with OpenMP (C-level parallelization library) support but "
         "could not find it on your system. To enable better performance "
         "OpenMP must be installed (ex. ``brew install omp`` on Mac with "
         "HomeBrew). Otherwise, try installing Pykdtree from source (ex. "
         "``pip install --no-binary pykdtree --force-install pykdtree``)."
-    )
+    ) from err

--- a/setup.py
+++ b/setup.py
@@ -20,8 +20,9 @@ import sys
 import re
 
 import numpy as np
-from Cython.Build import cythonize
-from setuptools import setup, Extension
+from Cython.Build import build_ext
+from Cython.Distutils import Extension
+from setuptools import setup
 from setuptools.command.build_ext import build_ext
 
 
@@ -189,9 +190,10 @@ extensions = [
     Extension('pykdtree.kdtree', sources=['pykdtree/kdtree.pyx', 'pykdtree/_kdtree_core.c'],
               include_dirs=[np.get_include()],
               define_macros=[("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION")],
-              compiler_directions={"language_level": "3"},
+              cython_directives={"language_level": "3"},
               ),
 ]
+
 
 setup(
     name='pykdtree',
@@ -206,7 +208,7 @@ setup(
     install_requires=['numpy'],
     tests_require=['pytest'],
     zip_safe=False,
-    ext_modules=cythonize(extensions),
+    ext_modules=extensions,
     cmdclass={'build_ext': build_ext_subclass},
     classifiers=[
       'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
Closes #106

This attempts to provide a warning guiding users to a possible solution when the C extension fails to import. This is usually because OpenMP isn't available. The warning suggests either installing OpenMP or installing pykdtree from source (as they are probably installing from a binary wheel).

CC @user27182