### PR TITLE
Build wheels with numpy 2

### DIFF
--- a/.github/workflows/deploy-wheels.yml
+++ b/.github/workflows/deploy-wheels.yml
@@ -65,6 +65,9 @@ jobs:
           CIBW_TEST_COMMAND: "pytest -v --pyargs pykdtree"
           CIBW_TEST_REQUIRES: "pytest"
           CIBW_TEST_SKIP: "*_arm64 *_universal2:arm64"
+          # below only for building against unstable numpy
+          CIBW_BUILD_FRONTEND: "pip; args: --no-build-isolation"
+          CIBW_BEFORE_BUILD: "pip install --pre --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy cython setuptools versioneer"
 
       - name: Upload wheel(s) as build artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Numpy 2 isn't out yet, but for now the changes in this PR are required to build with numpy 2 (pre-release) which will produce wheels compatible with numpy 2 and numpy 1.