### PR TITLE
Enable Python 3.13 wheel building and switch to C17 C standard

### DIFF
--- a/.github/workflows/deploy-wheels.yml
+++ b/.github/workflows/deploy-wheels.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.20.0
         env:
-          CIBW_SKIP: "cp36-* cp37-* cp38-* cp313-* pp* *i686 *-musllinux_aarch64"
+          CIBW_SKIP: "cp36-* cp37-* cp38-* pp* *i686 *-musllinux_aarch64"
           CIBW_ARCHS: "${{ matrix.cibw_archs }}"
           CIBW_TEST_COMMAND: "pytest -v --pyargs pykdtree"
           CIBW_TEST_REQUIRES: "pytest"

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ class build_ext_subclass(build_ext):
         comp = self.compiler.compiler_type
         omp_comp, omp_link = _omp_compile_link_args(comp)
         if comp in ('unix', 'cygwin', 'mingw32'):
-            extra_compile_args = ['-std=c99', '-O3'] + omp_comp
+            extra_compile_args = ['-std=c17', '-O3'] + omp_comp
             extra_link_args = omp_link
         elif comp == 'msvc':
             extra_compile_args = ['/Ox'] + omp_comp


### PR DESCRIPTION
See https://py-free-threading.github.io/debugging/

We were getting:

```
  In file included from pykdtree/kdtree.c:13538:
  In file included from /Users/runner/miniforge3/conda-bld/pykdtree_1725442308828/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_/include/python3.13/internal/pycore_frame.h:13:
  /Users/runner/miniforge3/conda-bld/pykdtree_1725442308828/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_/include/python3.13/internal/pycore_code.h:540:15: error: expected parameter declarator
    540 | static_assert(COLD_EXIT_INITIAL_VALUE > ADAPTIVE_COOLDOWN_VALUE,
        |               ^
  /Users/runner/miniforge3/conda-bld/pykdtree_1725442308828/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_/include/python3.13/internal/pycore_backoff.h:125:33: note: expanded from macro 'COLD_EXIT_INITIAL_VALUE'
    125 | #define COLD_EXIT_INITIAL_VALUE 64
        |                                 ^
  In file included from pykdtree/kdtree.c:13538:
  In file included from /Users/runner/miniforge3/conda-bld/pykdtree_1725442308828/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_/include/python3.13/internal/pycore_frame.h:13:
  /Users/runner/miniforge3/conda-bld/pykdtree_1725442308828/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_/include/python3.13/internal/pycore_code.h:540:15: error: expected ')'
  /Users/runner/miniforge3/conda-bld/pykdtree_1725442308828/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_/include/python3.13/internal/pycore_backoff.h:125:33: note: expanded from macro 'COLD_EXIT_INITIAL_VALUE'
    125 | #define COLD_EXIT_INITIAL_VALUE 64
        |                                 ^
  /Users/runner/miniforge3/conda-bld/pykdtree_1725442308828/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_/include/python3.13/internal/pycore_code.h:540:14: note: to match this '('
    540 | static_assert(COLD_EXIT_INITIAL_VALUE > ADAPTIVE_COOLDOWN_VALUE,
        |              ^
  /Users/runner/miniforge3/conda-bld/pykdtree_1725442308828/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_/include/python3.13/internal/pycore_code.h:540:1: error: type specifier missing, defaults to 'int'; ISO C99 and later do not support implicit int [-Wimplicit-int]
    540 | static_assert(COLD_EXIT_INITIAL_VALUE > ADAPTIVE_COOLDOWN_VALUE,
        | ^
        | int
  3 errors generated.
```

Hopefully fixes it, but I need to read more into if we should be doing more to protect against free-threaded Python 3.13.