### PR TITLE
Fix the wrong syntax of pip install

### DIFF
--- a/pykdtree/__init__.py
+++ b/pykdtree/__init__.py
@@ -9,5 +9,5 @@ except ImportError as err:
         "could not find it on your system. To enable better performance "
         "OpenMP must be installed (ex. ``brew install omp`` on Mac with "
         "HomeBrew). Otherwise, try installing Pykdtree from source (ex. "
-        "``pip install --no-binary pykdtree --force-install pykdtree``)."
+        "``pip install --no-binary pykdtree --force-reinstall pykdtree``)."
     ) from err


### PR DESCRIPTION
pip install has no such option: --force-install
<img width="867" alt="image" src="https://github.com/user-attachments/assets/743d8ab7-9a77-4666-b30d-e604c91a615d">