### PR TITLE
Improve wheel building with ARM runners and newer ubuntu

### DIFF
--- a/.github/workflows/deploy-wheels.yml
+++ b/.github/workflows/deploy-wheels.yml
@@ -39,8 +39,10 @@ jobs:
             cibw_archs: "ARM64"
           - os: macos-13
             cibw_archs: "x86_64"
+            deploy_target: "13"
           - os: macos-14
             cibw_archs: "arm64"
+            deploy_target: "14"
           - os: ubuntu-24.04-arm
             cibw_archs: "aarch64"
           - os: ubuntu-22.04
@@ -62,8 +64,8 @@ jobs:
           CIBW_BUILD_VERBOSITY: 1
           # we use openmp (libomp) from homebrew which has a current limit of
           # macos 13 (Ventura): https://formulae.brew.sh/formula/libomp
-          CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=14
-          CIBW_BEFORE_BUILD_MACOS: "brew install libomp; echo $CIBW_ARCHS; if [[ $(sw_vers -productVersion) =~ ^13.* ]]; then export MACOSX_DEPLOYMENT_TARGET=13; fi"
+          CIBW_ENVIRONMENT_MACOS: "MACOSX_DEPLOYMENT_TARGET=${{ matrix.deploy_target }}"
+          CIBW_BEFORE_BUILD_MACOS: "brew install libomp"
 
       - name: Upload wheel(s) as build artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/deploy-wheels.yml
+++ b/.github/workflows/deploy-wheels.yml
@@ -63,7 +63,7 @@ jobs:
           # we use openmp (libomp) from homebrew which has a current limit of
           # macos 13 (Ventura): https://formulae.brew.sh/formula/libomp
           CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=14
-          CIBW_BEFORE_BUILD_MACOS: "brew install libomp; echo $CIBW_ARCHS; if [[ $CIBW_ARCHS == \"x86_64\" ]]; then export MACOSX_DEPLOYMENT_TARGET=13; fi"
+          CIBW_BEFORE_BUILD_MACOS: "brew install libomp; echo $CIBW_ARCHS; if [[ $(sw_vers -productVersion) =~ ^13.* ]]; then export MACOSX_DEPLOYMENT_TARGET=13; fi"
 
       - name: Upload wheel(s) as build artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/deploy-wheels.yml
+++ b/.github/workflows/deploy-wheels.yml
@@ -59,6 +59,7 @@ jobs:
           CIBW_TEST_COMMAND: "pytest -v --pyargs pykdtree"
           CIBW_TEST_REQUIRES: "pytest"
           CIBW_TEST_SKIP: "*-win_arm64"
+          CIBW_BUILD_VERBOSITY: 1
           # we use openmp (libomp) from homebrew which has a current limit of
           # macos 13 (Ventura): https://formulae.brew.sh/formula/libomp
           CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=13

--- a/.github/workflows/deploy-wheels.yml
+++ b/.github/workflows/deploy-wheels.yml
@@ -34,28 +34,22 @@ jobs:
       matrix:
         include:
           - os: windows-2019
-            cibw_archs: "AMD64 ARM64"
-            artifact_name: "win"
+            cibw_archs: "AMD64"
+          - os: windows-2019
+            cibw_archs: "ARM64"
           - os: macos-13
-            cibw_archs: "x86_64 arm64"
-            artifact_name: "mac"
-          - os: "ubuntu-20.04"
-            cibw_archs: "aarch64"
-            artifact_name: "ubuntu-aarch"
-          - os: "ubuntu-20.04"
             cibw_archs: "x86_64"
-            artifact_name: "ubuntu-x86_64"
+          - os: macos-14
+            cibw_archs: "arm64"
+          - os: ubuntu-24.04-arm
+            cibw_archs: "aarch64"
+          - os: ubuntu-22.04
+            cibw_archs: "x86_64"
 
     steps:
       - uses: actions/checkout@v4
       - run: |
           git fetch --prune --unshallow
-
-      - name: Set up QEMU
-        if: runner.os == 'Linux'
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: all
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.22.0
@@ -64,7 +58,7 @@ jobs:
           CIBW_ARCHS: "${{ matrix.cibw_archs }}"
           CIBW_TEST_COMMAND: "pytest -v --pyargs pykdtree"
           CIBW_TEST_REQUIRES: "pytest"
-          CIBW_TEST_SKIP: "*_arm64 *_universal2:arm64"
+          CIBW_TEST_SKIP: "*-win_arm64"
           # we use openmp (libomp) from homebrew which has a current limit of
           # macos 13 (Ventura): https://formulae.brew.sh/formula/libomp
           CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=13
@@ -72,7 +66,7 @@ jobs:
       - name: Upload wheel(s) as build artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: wheels-${{ matrix.artifact_name }}
+          name: "wheels-${{ matrix.os }}-${{ matrix.cibw_archs }}"
           path: ./wheelhouse/*.whl
 
   upload_pypi:
@@ -84,25 +78,11 @@ jobs:
         with:
           name: sdist
           path: dist
-      - name: Download wheels artifact - win
+      - name: Download wheels artifacts
         uses: actions/download-artifact@v4
         with:
-          name: wheels-win
-          path: dist
-      - name: Download wheels artifact - mac
-        uses: actions/download-artifact@v4
-        with:
-          name: wheels-mac
-          path: dist
-      - name: Download wheels artifact - ubuntu aarch
-        uses: actions/download-artifact@v4
-        with:
-          name: wheels-ubuntu-aarch
-          path: dist
-      - name: Download wheels artifact - ubuntu x86_64
-        uses: actions/download-artifact@v4
-        with:
-          name: wheels-ubuntu-x86_64
+          pattern: wheels-*
+          merge-multiple: true
           path: dist
       - name: Publish package to PyPI
         if: github.event.action == 'published'

--- a/.github/workflows/deploy-wheels.yml
+++ b/.github/workflows/deploy-wheels.yml
@@ -63,6 +63,7 @@ jobs:
           # we use openmp (libomp) from homebrew which has a current limit of
           # macos 13 (Ventura): https://formulae.brew.sh/formula/libomp
           CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=13
+          CIBW_BEFORE_BUILD_MACOS: "brew install libomp"
 
       - name: Upload wheel(s) as build artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/deploy-wheels.yml
+++ b/.github/workflows/deploy-wheels.yml
@@ -63,7 +63,7 @@ jobs:
           # we use openmp (libomp) from homebrew which has a current limit of
           # macos 13 (Ventura): https://formulae.brew.sh/formula/libomp
           CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=14
-          CIBW_BEFORE_BUILD_MACOS: "brew install libomp; echo $CIBW_ARCHS; if [[ $CIBW_ARCHS == \"x86_64\" ]]; export MACOSX_DEPLOYMENT_TARGET=13; fi"
+          CIBW_BEFORE_BUILD_MACOS: "brew install libomp; echo $CIBW_ARCHS; if [[ $CIBW_ARCHS == \"x86_64\" ]]; then export MACOSX_DEPLOYMENT_TARGET=13; fi"
 
       - name: Upload wheel(s) as build artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/deploy-wheels.yml
+++ b/.github/workflows/deploy-wheels.yml
@@ -39,7 +39,7 @@ jobs:
             cibw_archs: "ARM64"
           - os: macos-13
             cibw_archs: "x86_64"
-          - os: macos-14
+          - os: macos-13
             cibw_archs: "arm64"
           - os: ubuntu-24.04-arm
             cibw_archs: "aarch64"

--- a/.github/workflows/deploy-wheels.yml
+++ b/.github/workflows/deploy-wheels.yml
@@ -39,7 +39,7 @@ jobs:
             cibw_archs: "ARM64"
           - os: macos-13
             cibw_archs: "x86_64"
-          - os: macos-13
+          - os: macos-14
             cibw_archs: "arm64"
           - os: ubuntu-24.04-arm
             cibw_archs: "aarch64"
@@ -62,8 +62,8 @@ jobs:
           CIBW_BUILD_VERBOSITY: 1
           # we use openmp (libomp) from homebrew which has a current limit of
           # macos 13 (Ventura): https://formulae.brew.sh/formula/libomp
-          CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=13
-          CIBW_BEFORE_BUILD_MACOS: "brew install libomp"
+          CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=14
+          CIBW_BEFORE_BUILD_MACOS: "brew install libomp; echo $CIBW_ARCHS; if [[ $CIBW_ARCHS == \"x86_64\" ]]; export MACOSX_DEPLOYMENT_TARGET=13; fi"
 
       - name: Upload wheel(s) as build artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
- use new github arm runner to build aarch64 wheels natively, remove QEMU
- update ubuntu to 22.04: 20.04 will soon be removed
- build arm64 mac wheels natively using arm64 mac runner and re-enable mac arm64 tests
- download all wheels using `merge-multiple` option
- split windows jobs by arch to speed up CI
- remove `artifact_name`, use existing `os` and `cibw_archs` to name upload artifacts