### PR TITLE
Fix additional integer overflow issues

### DIFF
--- a/pykdtree/_kdtree_core.c
+++ b/pykdtree/_kdtree_core.c
@@ -836,14 +836,10 @@ void search_tree_float_int32_t(Tree_float_int32_t *tree, float *pa, float *point
     int8_t no_dims = tree->no_dims;
     float *bbox = tree->bbox;
     uint32_t *pidx = tree->pidx;
-    uint32_t j = 0;
-#if defined(_MSC_VER) && defined(_OPENMP)
-    int32_t i = 0;
-    int32_t local_num_points = (int32_t) num_points;
-#else
-    uint32_t i;
-    uint32_t local_num_points = num_points;
-#endif
+    /* use 64-bit ints for indexing to avoid overflow, use signed ints to support all Openmp implementations */
+    int64_t i = 0;
+    int64_t j = 0;
+    int64_t local_num_points = (int64_t) num_points;
     Node_float_int32_t *root = (Node_float_int32_t *)tree->root;
 
     /* Queries are OpenMP enabled */
@@ -1412,14 +1408,10 @@ void search_tree_float_int64_t(Tree_float_int64_t *tree, float *pa, float *point
     int8_t no_dims = tree->no_dims;
     float *bbox = tree->bbox;
     uint64_t *pidx = tree->pidx;
-    uint64_t j = 0;
-#if defined(_MSC_VER) && defined(_OPENMP)
+    /* use 64-bit ints for indexing to avoid overflow, use signed ints to support all Openmp implementations */
     int64_t i = 0;
+    int64_t j = 0;
     int64_t local_num_points = (int64_t) num_points;
-#else
-    uint64_t i;
-    uint64_t local_num_points = num_points;
-#endif
     Node_float_int64_t *root = (Node_float_int64_t *)tree->root;
 
     /* Queries are OpenMP enabled */
@@ -2057,14 +2049,10 @@ void search_tree_double_int32_t(Tree_double_int32_t *tree, double *pa, double *p
     int8_t no_dims = tree->no_dims;
     double *bbox = tree->bbox;
     uint32_t *pidx = tree->pidx;
-    uint32_t j = 0;
-#if defined(_MSC_VER) && defined(_OPENMP)
-    int32_t i = 0;
-    int32_t local_num_points = (int32_t) num_points;
-#else
-    uint32_t i;
-    uint32_t local_num_points = num_points;
-#endif
+    /* use 64-bit ints for indexing to avoid overflow, use signed ints to support all Openmp implementations */
+    int64_t i = 0;
+    int64_t j = 0;
+    int64_t local_num_points = (int64_t) num_points;
     Node_double_int32_t *root = (Node_double_int32_t *)tree->root;
 
     /* Queries are OpenMP enabled */
@@ -2633,14 +2621,10 @@ void search_tree_double_int64_t(Tree_double_int64_t *tree, double *pa, double *p
     int8_t no_dims = tree->no_dims;
     double *bbox = tree->bbox;
     uint64_t *pidx = tree->pidx;
-    uint64_t j = 0;
-#if defined(_MSC_VER) && defined(_OPENMP)
+    /* use 64-bit ints for indexing to avoid overflow, use signed ints to support all Openmp implementations */
     int64_t i = 0;
+    int64_t j = 0;
     int64_t local_num_points = (int64_t) num_points;
-#else
-    uint64_t i;
-    uint64_t local_num_points = num_points;
-#endif
     Node_double_int64_t *root = (Node_double_int64_t *)tree->root;
 
     /* Queries are OpenMP enabled */

--- a/pykdtree/_kdtree_core.c.mako
+++ b/pykdtree/_kdtree_core.c.mako
@@ -716,15 +716,10 @@ void search_tree_${DTYPE}_${ITYPE}(Tree_${DTYPE}_${ITYPE} *tree, ${DTYPE} *pa, $
     int8_t no_dims = tree->no_dims;
     ${DTYPE} *bbox = tree->bbox;
     u${ITYPE} *pidx = tree->pidx;
-#if defined(_MSC_VER) && defined(_OPENMP)
+    /* use 64-bit ints for indexing to avoid overflow, use signed ints to support all Openmp implementations */
     int64_t i = 0;
     int64_t j = 0;
     int64_t local_num_points = (int64_t) num_points;
-#else
-    uint64_t i;
-    uint64_t j;
-    uint64_t local_num_points = (uint64_t) num_points;
-#endif
     Node_${DTYPE}_${ITYPE} *root = (Node_${DTYPE}_${ITYPE} *)tree->root;
 
     /* Queries are OpenMP enabled */

--- a/pykdtree/kdtree.pyx
+++ b/pykdtree/kdtree.pyx
@@ -162,7 +162,7 @@ cdef class KDTree:
 
         # Get tree info
         self.n = <uint64_t>data_pts.shape[0]
-        self._use_int32_t = self.n * <uint64_t>data_pts.shape[1] < UINT32_MAX
+        self._use_int32_t = self.n * data_pts.shape[1] < UINT32_MAX
         self.leafsize = <uint32_t>leafsize
         if data_pts.ndim == 1:
             self.ndim = 1

--- a/pykdtree/kdtree.pyx
+++ b/pykdtree/kdtree.pyx
@@ -162,7 +162,7 @@ cdef class KDTree:
 
         # Get tree info
         self.n = <uint64_t>data_pts.shape[0]
-        self._use_int32_t = self.n < UINT32_MAX
+        self._use_int32_t = self.n * <uint64_t>data_pts.shape[1] < UINT32_MAX
         self.leafsize = <uint32_t>leafsize
         if data_pts.ndim == 1:
             self.ndim = 1

--- a/pykdtree/test_tree.py
+++ b/pykdtree/test_tree.py
@@ -385,33 +385,46 @@ def test_empty_fail():
     except ValueError as e:
         assert 'non-empty' in str(e), str(e)
 
-def test_tree_n_lt_maxint32_nk_gt_maxint32():
-    # n < UINT32_MAX but n * k > UINT32_MAX -> still uses 32-bit index
-    data_pts = np.random.random((2**20, 2)).astype(np.float32)
-    query_pts = np.random.random((3, 2)).astype(np.float32)
+@pytest.mark.skip(reason="Requires ~50G RAM")
+def test_tree_n_lt_maxint32_n_query_k_gt_maxint32():
+    # n_points < UINT32_MAX but n_query * k > UINT32_MAX -> still uses 32-bit index
+    n_dim = 2
+    n_points = 2**20
+    n_query = 2**20 + 8
+    k = 2**12
+    data_pts = np.random.random((n_points, n_dim)).astype(np.float32)
+    query_pts = np.random.random((n_query, n_dim)).astype(np.float32)
     data_pts[0] = query_pts[0]
-    data_pts[1533] = query_pts[1]
-    data_pts[1048575] = query_pts[2]
+    data_pts[1533] = query_pts[15633]
+    data_pts[1048575] = query_pts[1048583]
     kdtree = KDTree(data_pts)
-    dist, idx = kdtree.query(query_pts, k=2**14)
-    assert idx.shape == (3, 2**14)
+    dist, idx = kdtree.query(query_pts, k=k)
+    assert idx.shape == (n_query, k)
     assert idx.dtype == np.uint32
     assert idx[0][0] == 0
-    assert idx[1][0] == 1533
-    assert idx[2][0] == 1048575
+    assert idx[15633][0] == 1533
+    assert idx[1048583][0] == 1048575
+    assert np.all(idx < data_pts.shape[0])
+    assert dist.shape == (n_query, k)
+    assert dist.dtype == np.float32
 
-@pytest.mark.skip(reason="Requires ~100G RAM, takes ~30mins to run")
-def test_tree_n_gt_maxint32():
-    # n > UINT32_MAX -> requires 64-bit index
-    data_pts = np.random.random((2**32 + 8, 2)).astype(np.float32)
-    query_pts = np.random.random((3, 2)).astype(np.float32)
+@pytest.mark.skip(reason="Requires ~50G RAM")
+def test_tree_n_points_n_dim_gt_maxint32():
+    # n_points < UINT32_MAX but n_points * n_dim > UINT32_MAX -> uses 64-bit index
+    n_dim = 2**6
+    n_points = 2**26 + 8
+    data_pts = np.random.random((n_points, n_dim)).astype(np.float32)
+    query_pts = np.random.random((3, n_dim)).astype(np.float32)
     data_pts[0] = query_pts[0]
     data_pts[874516] = query_pts[1]
-    data_pts[4294967300] = query_pts[2]
+    data_pts[67108871] = query_pts[2]
     kdtree = KDTree(data_pts)
-    dist, idx = kdtree.query(query_pts, k=12)
-    assert idx.shape == (3, 12)
+    dist, idx = kdtree.query(query_pts, k=4)
+    assert idx.shape == (3, 4)
     assert idx.dtype == np.uint64
     assert idx[0][0] == 0
     assert idx[1][0] == 874516
-    assert idx[2][0] == 4294967300
+    assert idx[2][0] == 67108871
+    assert np.all(idx < data_pts.shape[0])
+    assert dist.shape == (3, 4)
+    assert dist.dtype == np.float32


### PR DESCRIPTION
- correct the condition for using 32bit int indices
  - previous condition: `n_points < UINT_MAX`
  - however the data array in the C code has size `n_points * n_dim` and is indexed using a 32bit int type (see e.g. the PA macro)
  - this means results were incorrect for the case where `n_points < UINT_MAX` and `n_points * n_dim >= UINT_MAX`
  - new condition: `n_points * n_dim < UINT_MAX`
  - resolves #138
- render mako template
  - the generated _kdtree_core.c did not contain latest changes from _kdtree_core.c.mako (sorry my mistake)
  - this meant results were incorrect for the case `n_points < UINT_MAX` and `n_query * k >= UINT_MAX`
  - resolves #137
- use signed 64bit ints for the OpenMP loop on all platforms
  - to support OpenMP versions < 3 which only allow signed integers as loop counters